### PR TITLE
Compatibility Fix for Non-CUDA devices

### DIFF
--- a/convex_adversarial/dual.py
+++ b/convex_adversarial/dual.py
@@ -325,7 +325,10 @@ class DualReLU(nn.Module):
     def affine(self, *xs, I_ind=None): 
         x = xs[-1]
 
-        d = self.d.cuda(device=x.get_device())
+        if self.d.is_cuda:
+            d = self.d.cuda(device=x.get_device())
+        else:
+            d = self.d
         if x.dim() > d.dim():
             d = d.unsqueeze(1)
 


### PR DESCRIPTION
This pull-request restores the usability of the library when learning on non-CUDA devices. There was one place in the code in which it was assumed that CUDA was used for training the ANN, while in others, this was not assumed. The fix uses the same code for checking if the system runs on CUDA as in the other places.